### PR TITLE
Compatibility fix for East Scarpe

### DIFF
--- a/JoysOfEfficiency/Huds/FishingProbabilitiesBox.cs
+++ b/JoysOfEfficiency/Huds/FishingProbabilitiesBox.cs
@@ -121,7 +121,7 @@ namespace JoysOfEfficiency.Huds
                     {
                         for (int i = 0; i < array.Length; i += 2)
                         {
-                            dictionary2.Add(array[i], array[i + 1]);
+                            dictionary2[array[i]] = array[i + 1];
                         }
                     }
 


### PR DESCRIPTION
The East Scarpe mod has distinct fishing areas, like the vanilla Forest map. Unlike the Forest map, however, certain fish overlap between the different areas, so they are listed twice or thrice for the same season. This is leading to errors when fishing with both mods installed; see [this sample log](https://smapi.io/log/632694fd0bc9415394bcb2875b43f6b1) provided by Vibel on Discord. This patch fixes the fish ID gathering to handle duplicate IDs gracefully, which should make the two mods compatible.